### PR TITLE
fix the issue #393

### DIFF
--- a/helpers/general_functions.py
+++ b/helpers/general_functions.py
@@ -249,6 +249,23 @@ def html_escape(text):
 
     return "".join(html_escape_table.get(c,c) for c in text)
 
+
+def translate_exclude_tags(text, translation_map):
+    # type: (str, dict) -> str
+    striped_text = ''
+
+    tag_pattern = re.compile(r'<.+?>', re.UNICODE)
+    tags = re.findall(tag_pattern, text)
+    contents = re.split(tag_pattern, text)
+
+    for i in range(len(tags)):
+        striped_text += contents[i].translate(translation_map)
+        striped_text += tags[i]
+    striped_text += contents[-1].translate(translation_map)
+
+    return striped_text
+
+
 # def encryptFile(path, key):
 #     """
 #     encrypt a file on path using the key (DES encryption)

--- a/processors/prepare/scrubber.py
+++ b/processors/prepare/scrubber.py
@@ -4,8 +4,12 @@ import sys
 import unicodedata
 import os
 import pickle
+
+import time
+
 import debug.log as debug
 import helpers.constants as constants
+import helpers.general_functions as general_functions
 
 from flask import request, session
 import codecs
@@ -469,11 +473,6 @@ def remove_punctuation(text, apos, hyphen, amper, tags, previewing):
         # apos is removed from the remove_punctuation_map
         del remove_punctuation_map[39]  # apostrophe is removed from map
 
-    if 'xmlhandlingoptions' in session:
-        # if (keeping tags) remove '<' and '>' from the punctuation map.
-        del remove_punctuation_map[60]
-        del remove_punctuation_map[62]
-
     if previewing:
         del remove_punctuation_map[8230]
 
@@ -513,7 +512,7 @@ def remove_punctuation(text, apos, hyphen, amper, tags, previewing):
         del remove_punctuation_map[38]      # Remove chosen ampersand from remove_punctuation_map
 
     # now remove all punctuation symbols still in the map
-    text = text.translate(remove_punctuation_map)
+    text = general_functions.translate_exclude_tags(text, remove_punctuation_map)
 
     return text
 
@@ -544,7 +543,7 @@ def remove_digits(text, previewing):
         pass
     pickle.dump(remove_digit_map, open(digit_filename, 'wb'))  # cache the digit map
 
-    text = text.translate(remove_digit_map)  # remove all unicode digits from text
+    text = general_functions.translate_exclude_tags(text, remove_digit_map)
 
     return text
 


### PR DESCRIPTION
for now, all the tags will not be harmed by remove punctuation and remove digits (but will turn into lower case, and that is okay to me.)

this method is takes only 0.06 sec to scrub GenAB, and keeps all the tags unharmed by strip punctuation and strip digit. (original method takes 0.01 sec)
for large file without tag, the speed is nearly the same (mobi dick, this method takes 0.16 sec whereas the original method takes 0.14 sec)