### PR TITLE
Renaming of Block Titles

### DIFF
--- a/lexos/templates/cut.html
+++ b/lexos/templates/cut.html
@@ -20,7 +20,7 @@
 </script>
 {% endblock %}
 
-{% block title %}cutter{% endblock %}
+{% block title %}Cutter{% endblock %}
 
 {% block options %}
 

--- a/lexos/templates/dendrogram.html
+++ b/lexos/templates/dendrogram.html
@@ -17,7 +17,7 @@
     <style type="text/css"></style>
 {% endblock %}
 
-{% block title %}analyzer{% endblock %}
+{% block title %}Hierarchical Clustering{% endblock %}
 
 
 {% block options %}

--- a/lexos/templates/kmeans.html
+++ b/lexos/templates/kmeans.html
@@ -43,7 +43,7 @@
 
 {% endblock %}
 
-{% block title %}analyzer{% endblock %}
+{% block title %}K-Means Clustering{% endblock %}
 
 
 {% block options %}

--- a/lexos/templates/manage.html
+++ b/lexos/templates/manage.html
@@ -29,7 +29,7 @@
 </style>
 {% endblock %}
 
-{% block title %}manage{% endblock %}
+{% block title %}Manage{% endblock %}
 
 {% block options %}
 <div class="row container">

--- a/lexos/templates/multicloud.html
+++ b/lexos/templates/multicloud.html
@@ -144,7 +144,7 @@ $(document).ready( function () {
 </script>
 {% endblock %}
 
-{% block title %}visualizer{% endblock %}
+{% block title %}Multicloud{% endblock %}
 
 {% block options %}
 <div class="row">

--- a/lexos/templates/rwanalysis.html
+++ b/lexos/templates/rwanalysis.html
@@ -57,7 +57,7 @@ $(document).ready( function () {
 </script>
 {% endblock %}
 
-{% block title %}visualizer{% endblock %}
+{% block title %}Rolling Windows{% endblock %}
 
 {% block options %}
 <!-- Title -->

--- a/lexos/templates/scrub.html
+++ b/lexos/templates/scrub.html
@@ -61,7 +61,7 @@
 </script>
 {% endblock %}
 
-{% block title %}scrubber{% endblock %}
+{% block title %}Scrubber{% endblock %}
 
 {% block options %}
 

--- a/lexos/templates/similarity.html
+++ b/lexos/templates/similarity.html
@@ -15,7 +15,7 @@
 
 {% endblock %}
 
-{% block title %}analyzer{% endblock %}
+{% block title %}Similarity Query{% endblock %}
 
 {% block options %}
     <input type="hidden" id="num_active_files" value="{{ labels|len }}"

--- a/lexos/templates/statistics.html
+++ b/lexos/templates/statistics.html
@@ -59,7 +59,7 @@ $(document).ready( function () {
 <style type="text/css">
 .to-right { text-align: right; float: right !important; margin: 4px auto;}
 </style>{% endblock %}
-{% block title %}statistics{% endblock %}
+{% block title %}Statistics{% endblock %}
 
 {% block options %}
 <div class="row">

--- a/lexos/templates/tokenizer.html
+++ b/lexos/templates/tokenizer.html
@@ -409,7 +409,7 @@ $(document).ready(function() {
 });//end document.ready()
 </script>
 {% endblock %}
-{% block title %}tokenizer{% endblock %}
+{% block title %}Tokenizer{% endblock %}
 {% block options %}
 <input type="hidden" id="tempLabelsOn" value="{{ tempLabelsOn or False }}" />
  	<div class="row">

--- a/lexos/templates/topword.html
+++ b/lexos/templates/topword.html
@@ -12,7 +12,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 {% endblock %}
-{% block title %}analyzer{% endblock %}
+{% block title %}Topwords{% endblock %}
 
 
 {% block options %}

--- a/lexos/templates/upload.html
+++ b/lexos/templates/upload.html
@@ -5,7 +5,7 @@
 <script type="text/javascript" src="{{ url_for('static', filename='js/scripts_upload.js') }}?ver={{version}}"></script>
 {% endblock %}
 
-{% block title %}loader{% endblock %}
+{% block title %}Loader{% endblock %}
 
 {% block options %}
 <fieldset>

--- a/lexos/templates/viz.html
+++ b/lexos/templates/viz.html
@@ -28,7 +28,7 @@ $(function() {
 </style>
 {% endblock %}
 
-{% block title %}visualizer{% endblock %}
+{% block title %}BubbleViz{% endblock %}
 
 {% block options %}
 <div id="status-prepare"><img src="{{ url_for('static', filename='images/loading_icon.svg') }}?ver={{version}}" alt="Loading..."></div>
@@ -44,7 +44,7 @@ $(function() {
 			<!-- Need to empty the segmentlist value if Toggle All is checked -->
 			{% for fileID, label in labels.items() %}
 			<div class="forCheckBox">
-				<label>{{label}} 
+				<label>{{label}}
 					<input type="checkbox" name="segmentlist" class="minifilepreview" {{ 'checked' if fileID|unicode in session['cloudoption']['segmentlist'] }} id="{{fileID}}_selector" value="{{fileID}}">
 				</label>
 			</div>
@@ -55,7 +55,7 @@ $(function() {
 		</div>
 	</div>
 </div>
-<div class="col-md-6">	
+<div class="col-md-6">
 	<legend>Filtering Options</legend>
 		<label>Graph Size:
 			<input type="number" min="100" max="3000" step="100" id="graphsize" name="graphsize" value="{{ session['bubblevisoption']['graphsize']}}"/>
@@ -86,7 +86,7 @@ $(function() {
 </div>
 
 <!-- Canvg Used for Save to PNG -->
-<script type="text/javascript" src="http://gabelerner.github.io/canvg/rgbcolor.js"></script> 
+<script type="text/javascript" src="http://gabelerner.github.io/canvg/rgbcolor.js"></script>
 <script type="text/javascript" src="http://gabelerner.github.io/canvg/StackBlur.js"></script>
 <script type="text/javascript" src="http://gabelerner.github.io/canvg/canvg.js"></script>
 <canvas id="svg-canvas" style="display:none;"></canvas>

--- a/lexos/templates/wordcloud.html
+++ b/lexos/templates/wordcloud.html
@@ -41,7 +41,7 @@ $(document).ready( function () {
 </script>
 {% endblock %}
 
-{% block title %}visualizer{% endblock %}
+{% block title %}Word Cloud{% endblock %}
 
 {% block options %}
 <div class="row">
@@ -59,7 +59,7 @@ $(document).ready(function() {
   }
   var config = {
     columns: [{ title: "Term" }, { title: "Count" }],
-    data: data    
+    data: data
   }
   $('#termcounts').DataTable(config);
 });
@@ -100,7 +100,7 @@ $(document).ready(function() {
   </div>
 <!--   <div class="col-md-1">
     {% if JSONObj %}
-    <div id="statsBtn"> 
+    <div id="statsBtn">
       <a class="btn bttn bttn-action" id="viewstats" data-toggle="modal" data-target="#word-count-modal">View Word Counts</a>
     </div>
     {% endif %}
@@ -117,7 +117,7 @@ $(document).ready(function() {
       <div id="vizcreateoptions" style="padding-left:15px;">
         {% for fileID, label in labels.items() %}
           <div class="forCheckBox">
-            <label>{{label}} 
+            <label>{{label}}
               <input type="checkbox" name="segmentlist" class="minifilepreview" {{ 'checked' if fileID|unicode in session['cloudoption']['segmentlist']}} id="{{fileID}}_selector" value="{{fileID}}">
             </label>
           </div>
@@ -159,7 +159,7 @@ $(document).ready(function() {
   <p><label for="maxwords">Number of words:</label> <input type="number" value="250" min="1" id="maxwords">
   <!--<p><label for="colours">Colours:</label> <a href="#" id="random-palette">get random palette</a>-->
   <p><label>Download:</label>
-    <a id="download-svg" href="#" target="_blank" class="btn btn-primary" role="button">SVG</a> 
+    <a id="download-svg" href="#" target="_blank" class="btn btn-primary" role="button">SVG</a>
     <a id="download-png" target="_blank" class="btn btn-info" role="button">PNG</a>
   </p>
 </div>


### PR DESCRIPTION
## Block Titles Changed to Uppercase Space Format of Tool Names
The block titles have been changed to the format voted most popular and readable by the English student users of Lexos. 

See pull request [#692](https://github.com/WheatonCS/Lexos/pull/692) for discussion regarding this decision. 