### PR TITLE
Update .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,7 +17,7 @@ indent_size = 4
 # 2 space indentation for js
 [*.js]
 indent_style = space
-indent_size = 4
+indent_size = 2
 
 # all the yaml and json file
 [{*.json,*.yml}]


### PR DESCRIPTION
### Change js indent size to **2**.
We may want to change this since this file will overwrite the editor settings in PyCharm. Alternatively we also can tell PyCharm not to read this file..