### PR TITLE
Capitalized Statistics block title so its uniform with the rest.

### DIFF
--- a/lexos/templates/statistics.html
+++ b/lexos/templates/statistics.html
@@ -22,7 +22,7 @@
             src="{{ url_for('static', filename='js/scripts_statistics.js') }}?ver={{ version }}"></script>
 {% endblock %}
 
-{% block title %}statistics{% endblock %}
+{% block title %}Statistics{% endblock %}
 
 {% block options %}
     <div class="row">


### PR DESCRIPTION
For whatever reason statistics was the only block title not capitalized so I changed it because it was irritating me. 