### PR TITLE
Bugfix/statistics descriptions

### DIFF
--- a/lexos/static/js/scripts_statistics.js
+++ b/lexos/static/js/scripts_statistics.js
@@ -10,7 +10,7 @@ function formatFileReportResponse (response) {
   const unit = response['unit']
   const mean = `Average document size is ${response['mean']} ${unit}.`
   const stdDeviation = `Standard deviation of documents is ${response['std_deviation']} ${unit}.`
-  const IQR = `Inter quartile range of documents is ${response['inter_quartile_range']} ${unit}.`
+  const IQR = `Interquartile range of documents is ${response['inter_quartile_range']} ${unit}.`
 
   // Find if anomaly detected by standard error analysis.
   const noAnomalySe = response['anomaly_se_small'].length === 0 && response['anomaly_se_large'].length === 0
@@ -27,8 +27,8 @@ function formatFileReportResponse (response) {
   const noAnomalyIqr = response['anomaly_iqr_small'].length === 0 && response['anomaly_iqr_large'].length === 0
   // Pick appropriate result for standard error analysis.
   const anomalyIqrResult =
-    noAnomalyIqr ? '<b>No</b> anomaly detected by inter quartile range test.'
-      : 'Anomaly <b>detected</b> by inter quartile range test.' +
+    noAnomalyIqr ? '<b>No</b> anomaly detected by interquartile range test.'
+      : 'Anomaly <b>detected</b> by interquartile range test.' +
       response['anomaly_iqr_small'].map(
         function (file) { return `<p style="padding-left: 20px"><b>Small:</b> ${file}</p>` }) +
       response['anomaly_iqr_large'].map(

--- a/lexos/templates/statistics.html
+++ b/lexos/templates/statistics.html
@@ -74,9 +74,11 @@
             <div id="file-report"
                  class="row col-lg-4 col-md-4"
                  style="margin-left: 30px; margin-top: 35px; box-shadow: 0 0 10px 0 #888; padding:20px">
-                <p id="file-report-mean"></p>
-                <p id="file-report-std-deviation"></p>
-                <p id="file-report-IQR"></p>
+                <p id="file-report-mean"class="tooltip-trigger" data-toggle="tooltip" data-html="true" data-placement="right" data-container="body" title="The average is a sum of a collection of grams divided by the number of grams in the collection." style="font-size:14px;"></p>
+                <p id="file-report-std-deviation"
+                   class="tooltip-trigger" data-toggle="tooltip" data-html="true" data-placement="right" data-container="body" title="The standard deviation is a measure that is used to quantify the amount of variation or dispersion of a set of data values. A low standard deviation indicates that the data points tend to be close to the mean of the set, while a high standard deviation indicates that the data points are spread out over a wider range of values." style="font-size:14px;"></p>
+                <p id="file-report-IQR"
+                   class="tooltip-trigger" data-toggle="tooltip" data-html="true" data-placement="right" data-container="body" title="The interquartile range is a measure of statistical dispersion, being equal to the difference between 75th and 25th percentiles, or between upper and lower quartiles." style="font-size:14px;"></p>
                 <p id="file-report-anomaly-se-result"></p>
                 <p id="file-report-anomaly-iqr-result"></p>
             </div>


### PR DESCRIPTION
Issues pertaining to statistics https://github.com/WheatonCS/Lexos/issues/773
- Added hover over descriptions for average, standard deviation, and interquartile range. The question mark tooltip cannot be generated here since an ajax call is made. Instead, hovering over any part of the sentence activates the tooltip. 

- Fixed spelling error for interquartile. 
