### PR TITLE
Removed Link In Footer That Just Links To Lexos

### DIFF
--- a/lexos/templates/base.html
+++ b/lexos/templates/base.html
@@ -196,7 +196,7 @@
 	<footer class="container">
 		<span id="aboutus">
 
-			<a href="http://lexos.wheatoncollege.edu/" target="_blank">Lexos v{{version}}</a>
+			Lexos v{{version}}
 			© 2018
 
 			<a href="http://lexomics.wheatoncollege.edu" target="_blank">Lexomics Research Group</a>

--- a/lexos/templates/base.html
+++ b/lexos/templates/base.html
@@ -196,8 +196,7 @@
 	<footer class="container">
 		<span id="aboutus">
 
-			Lexos v{{version}}
-			© 2018
+			Lexos v{{version}} © 2018
 
 			<a href="http://lexomics.wheatoncollege.edu" target="_blank">Lexomics Research Group</a>
 			 ·


### PR DESCRIPTION
Per request I removed this link as it simply brings you back to the lexos upload page which is pretty useless where it is. 