### PR TITLE
Bugfix/dendro appearance

### DIFF
--- a/lexos/models/dendro_model.py
+++ b/lexos/models/dendro_model.py
@@ -1,4 +1,4 @@
-"""This is a model to produce dendrograms of the dtms."""
+"""This is a model to produce dendrograms of the dtm."""
 
 import math
 import pandas as pd
@@ -89,15 +89,15 @@ class DendrogramModel(BaseModel):
         :param figure: The dendrogram result that need to be changed.
         :return: The formatted, extended figure.
         """
-        if self._dendro_option.orientation == "top":
-            return self.extend_top_figure(figure=figure)
+        if self._dendro_option.orientation == "bottom":
+            return self.extend_bottom_figure(figure=figure)
         elif self._dendro_option.orientation == "left":
             return self.extend_left_figure(figure=figure)
         else:
             raise ValueError("Invalid orientation.")
 
     @staticmethod
-    def get_dummy_scatter(x_value: int) -> Scatter:
+    def get_dummy_scatter(x_value: float) -> Scatter:
         """Creates a invisible scatter point at (x_value, 0)
 
         Use this function to help extend the margin of the dendrogram plot.
@@ -112,8 +112,8 @@ class DendrogramModel(BaseModel):
             hoverinfo="skip"
         )
 
-    def extend_top_figure(self, figure: Figure) -> Figure:
-        """Extend top orientation figure.
+    def extend_bottom_figure(self, figure: Figure) -> Figure:
+        """Extend bottom orientation figure.
 
         :param figure: The dendrogram result that need to be changed.
         :return: The formatted, extended figure.
@@ -124,7 +124,25 @@ class DendrogramModel(BaseModel):
                  for file_id in self._doc_term_matrix.index.values])
 
         # Extend the bottom margin to fit all labels.
-        figure['layout'].update({'margin': {'b': max_label_len * 3.5}})
+        figure['layout'].update({'margin': {'b': max_label_len * 3.3}})
+        # Calculate the space right most label needs.
+        right_margin = max_label_len * 4.7 if max_label_len * 4.7 > 80 else 80
+        # Update right margin as well.
+        figure['layout'].update({'margin': {'r': right_margin}})
+
+        # Find the max x value in the plot.
+        max_x = max([max(data['x']) for data in figure['data']])
+
+        # Calculate proper x coordinate the figure should extend to.
+        x_value = max_x + 3
+
+        # Get the dummy scatter plot.
+        dummy_scatter = self.get_dummy_scatter(x_value=x_value)
+
+        # Add dummy scatter to the figure. (Figure["data"] is a list)
+        figure["data"] += [dummy_scatter]
+
+        # Return the formatted figure.
         return figure
 
     def extend_left_figure(self, figure: Figure) -> Figure:
@@ -144,17 +162,14 @@ class DendrogramModel(BaseModel):
         # Find the max x value in the plot.
         max_x = max([max(data['x']) for data in figure['data']])
 
-        # Find the max_x round up to the nearest tenth digit.
+        # Calculate proper x coordinate the figure should extend to.
+        x_value = math.ceil(max_x * 10) / 10
 
-        return figure
+        # Get the dummy scatter plot.
+        dummy_scatter = self.get_dummy_scatter(x_value=x_value)
 
-    def extend_fig_boundary(self, figure: Figure) -> Figure:
-
-        if self._dendro_option.orientation == "top":
-
-            figure["layout"]["xaxis"].update({"rangemode": "normal"})
-        else:
-            x_value = [max([max(data['x']) for data in figure['data']]) + 3]
+        # Add dummy scatter to the figure. (Figure["data"] is a list)
+        figure["data"] += [dummy_scatter]
 
         return figure
 

--- a/lexos/models/dendro_model.py
+++ b/lexos/models/dendro_model.py
@@ -82,20 +82,38 @@ class DendrogramModel(BaseModel):
             labels=labels
         )
 
-    def extend_fig_margin(self, figure: Figure) -> Figure:
+    def extend_figure(self, figure: Figure) -> Figure:
+        """This function
 
+        :param figure:
+        :return:
+        """
+        if self._dendro_option.orientation == "top":
+            return self.extend_top_figure(figure=figure)
+        elif self._dendro_option.orientation == "left":
+            return self.extend_left_figure(figure=figure)
+        else:
+            raise ValueError("Invalid orientation.")
+
+    def extend_top_figure(self, figure: Figure) -> Figure:
         # Get the length of longest label.
         max_label_len = \
             max([len(self._id_temp_label_map[file_id])
                  for file_id in self._doc_term_matrix.index.values])
 
-        # Adjust style base on selected orientation.
-        if self._dendro_option.orientation in ["top", "bottom"]:
-            figure['layout'].update({'margin': {'b': max_label_len * 3.5}})
-            return figure
-        else:
-            figure['layout'].update({'margin': {'l': max_label_len * 7}})
-            return figure
+        # Extend the bottom margin to fit all labels.
+        figure['layout'].update({'margin': {'b': max_label_len * 3.5}})
+        return figure
+
+    def extend_left_figure(self, figure: Figure) -> Figure:
+        # Get the length of longest label.
+        max_label_len = \
+            max([len(self._id_temp_label_map[file_id])
+                 for file_id in self._doc_term_matrix.index.values])
+
+        # Extend the left margin to fit all labels.
+        figure['layout'].update({'margin': {'l': max_label_len * 7}})
+        return figure
 
     def extend_fig_boundary(self, figure: Figure) -> Figure:
 

--- a/lexos/models/dendro_model.py
+++ b/lexos/models/dendro_model.py
@@ -82,10 +82,12 @@ class DendrogramModel(BaseModel):
         )
 
     def extend_figure(self, figure: Figure) -> Figure:
-        """This function
+        """Extends the figure margins.
 
-        :param figure:
-        :return:
+        Use this function to extend figure margins so that long label will not
+        get cut off and the edging leafs will not touch the border of the plot.
+        :param figure: The dendrogram result that need to be changed.
+        :return: The formatted, extended figure.
         """
         if self._dendro_option.orientation == "top":
             return self.extend_top_figure(figure=figure)
@@ -96,10 +98,11 @@ class DendrogramModel(BaseModel):
 
     @staticmethod
     def get_dummy_scatter(x_value: int) -> Scatter:
-        """
+        """Creates a invisible scatter point at (x_value, 0)
 
-        :param x_value:
-        :return:
+        Use this function to help extend the margin of the dendrogram plot.
+        :param x_value: The desired x value we want to extend the margin to.
+        :return: An invisible scatter point at (x_value, 0)
         """
         return Scatter(
             x=[x_value],
@@ -110,7 +113,7 @@ class DendrogramModel(BaseModel):
         )
 
     def extend_top_figure(self, figure: Figure) -> Figure:
-        """
+        """Extend top orientation figure.
 
         :param figure:
         :return:
@@ -125,7 +128,7 @@ class DendrogramModel(BaseModel):
         return figure
 
     def extend_left_figure(self, figure: Figure) -> Figure:
-        """
+        """Extend left orientation figure.
 
         :param figure:
         :return:

--- a/lexos/models/dendro_model.py
+++ b/lexos/models/dendro_model.py
@@ -201,7 +201,6 @@ class DendrogramModel(BaseModel):
 
         :return: A HTML formatted div for plotly.
         """
-
         # Return the figure as div.
         return plot(
             figure_or_data=self._get_processed_dendrogram_figure(),

--- a/lexos/models/dendro_model.py
+++ b/lexos/models/dendro_model.py
@@ -157,7 +157,7 @@ class DendrogramModel(BaseModel):
                  for file_id in self._doc_term_matrix.index.values])
 
         # Extend the left margin to fit all labels.
-        figure['layout'].update({'margin': {'l': max_label_len * 7}})
+        figure['layout'].update({'margin': {'l': max_label_len * 6.2}})
 
         # Find the max x value in the plot.
         max_x = max([max(data['x']) for data in figure['data']])

--- a/lexos/models/dendro_model.py
+++ b/lexos/models/dendro_model.py
@@ -91,10 +91,31 @@ class DendrogramModel(BaseModel):
 
         # Adjust style base on selected orientation.
         if self._dendro_option.orientation in ["top", "bottom"]:
+            figure['layout'].update({'margin': {'b': max_label_len * 3.5}})
             return figure
         else:
             figure['layout'].update({'margin': {'l': max_label_len * 7}})
             return figure
+
+    def extend_fig_boundary(self, figure: Figure) -> Figure:
+
+        if self._dendro_option.orientation == "top":
+            x_value = [max([max(data['x']) for data in figure['data']]) + 3]
+            figure["layout"]["xaxis"].update({"rangemode": "normal"})
+        else:
+            x_value = [max([max(data['x']) for data in figure['data']]) + 3]
+
+        dummy_scatter = Scatter(
+            x=x_value,
+            y=[0],
+            opacity=0,
+            mode="markers",
+            hoverinfo="skip"
+        )
+
+        figure['data'] += [dummy_scatter]
+
+        return figure
 
     def get_dendrogram_div(self) -> str:
         """Generate the dendrogram div to send to the front end.
@@ -113,20 +134,13 @@ class DendrogramModel(BaseModel):
             }
         )
 
-        dummy_scatter = Scatter(
-            x=[max(figure['layout']['xaxis']['tickvals']) + 3],
-            y=[0],
-            opacity=0,
-            mode="markers",
-            hoverinfo="skip"
-        )
-
-        figure['data'] += [dummy_scatter]
-
         # Adjust figure style based on the selected orientation.
         figure = self.extend_fig_margin(figure=figure)
+        figure = self.extend_fig_boundary(figure=figure)
 
-        div = plot(figure, show_link=False, output_type="div",
-                   include_plotlyjs=False)
-
-        return div
+        return plot(
+            figure_or_data=figure,
+            show_link=False,
+            output_type="div",
+            include_plotlyjs=False
+        )

--- a/lexos/models/dendro_model.py
+++ b/lexos/models/dendro_model.py
@@ -190,6 +190,8 @@ class DendrogramModel(BaseModel):
             }
         )
 
+        # Note that the extend figure method is a hack.
+        # TODO: Once plotly has better solutions available, remove this method.
         # Adjust figure style based on the selected orientation.
         figure = self.extend_figure(figure=figure)
 

--- a/lexos/models/dendro_model.py
+++ b/lexos/models/dendro_model.py
@@ -115,8 +115,8 @@ class DendrogramModel(BaseModel):
     def extend_top_figure(self, figure: Figure) -> Figure:
         """Extend top orientation figure.
 
-        :param figure:
-        :return:
+        :param figure: The dendrogram result that need to be changed.
+        :return: The formatted, extended figure.
         """
         # Get the length of longest label.
         max_label_len = \
@@ -130,8 +130,8 @@ class DendrogramModel(BaseModel):
     def extend_left_figure(self, figure: Figure) -> Figure:
         """Extend left orientation figure.
 
-        :param figure:
-        :return:
+        :param figure: The dendrogram result that need to be changed.
+        :return: The formatted, extended figure.
         """
         # Get the length of longest label.
         max_label_len = \

--- a/lexos/models/dendro_model.py
+++ b/lexos/models/dendro_model.py
@@ -82,7 +82,7 @@ class DendrogramModel(BaseModel):
         )
 
     def extend_figure(self, figure: Figure) -> Figure:
-        """Extends the figure margins.
+        """Extend the figure margins.
 
         Use this function to extend figure margins so that long label will not
         get cut off and the edging leafs will not touch the border of the plot.
@@ -98,11 +98,11 @@ class DendrogramModel(BaseModel):
 
     @staticmethod
     def get_dummy_scatter(x_value: float) -> Scatter:
-        """Creates a invisible scatter point at (x_value, 0)
+        """Create a invisible scatter point at (x_value, 0).
 
         Use this function to help extend the margin of the dendrogram plot.
         :param x_value: The desired x value we want to extend the margin to.
-        :return: An invisible scatter point at (x_value, 0)
+        :return: An invisible scatter point at (x_value, 0).
         """
         return Scatter(
             x=[x_value],

--- a/lexos/models/dendro_model.py
+++ b/lexos/models/dendro_model.py
@@ -139,8 +139,8 @@ class DendrogramModel(BaseModel):
         # Get the dummy scatter plot.
         dummy_scatter = self.get_dummy_scatter(x_value=x_value)
 
-        # Add dummy scatter to the figure. (Figure["data"] is a list)
-        figure["data"] += [dummy_scatter]
+        # Add dummy scatter to the figure.
+        figure.add_trace(trace=dummy_scatter)
 
         # Return the formatted figure.
         return figure
@@ -168,17 +168,18 @@ class DendrogramModel(BaseModel):
         # Get the dummy scatter plot.
         dummy_scatter = self.get_dummy_scatter(x_value=x_value)
 
-        # Add dummy scatter to the figure. (Figure["data"] is a list)
-        figure["data"] += [dummy_scatter]
+        # Add dummy scatter to the figure.
+        figure.add_trace(trace=dummy_scatter)
 
+        # Return the formatted figure.
         return figure
 
-    def get_dendrogram_div(self) -> str:
-        """Generate the dendrogram div to send to the front end.
+    def _get_processed_dendrogram_figure(self) -> Figure:
+        """Get dendrogram figure and extend its boundary.
 
-        :return: a div
+        :return: The extended dendrogram figure.
         """
-        # Get the desired figure.
+        # Get the desired, unprocessed figure.
         figure = self._get_dendrogram_fig()
 
         # Update the size of the image.
@@ -192,12 +193,18 @@ class DendrogramModel(BaseModel):
 
         # Note that the extend figure method is a hack.
         # TODO: Once plotly has better solutions available, remove this method.
-        # Adjust figure style based on the selected orientation.
-        figure = self.extend_figure(figure=figure)
+        # Adjust figure style based on the selected orientation and return it.
+        return self.extend_figure(figure=figure)
+
+    def get_dendrogram_div(self) -> str:
+        """Generate the processed dendrogram figure.
+
+        :return: A HTML formatted div for plotly.
+        """
 
         # Return the figure as div.
         return plot(
-            figure_or_data=figure,
+            figure_or_data=self._get_processed_dendrogram_figure(),
             show_link=False,
             output_type="div",
             include_plotlyjs=False

--- a/lexos/models/dendro_model.py
+++ b/lexos/models/dendro_model.py
@@ -124,9 +124,9 @@ class DendrogramModel(BaseModel):
                  for file_id in self._doc_term_matrix.index.values])
 
         # Extend the bottom margin to fit all labels.
-        figure['layout'].update({'margin': {'b': max_label_len * 3.3}})
+        figure['layout'].update({'margin': {'b': max_label_len * 3.5}})
         # Calculate the space right most label needs.
-        right_margin = max_label_len * 4.7 if max_label_len * 4.7 > 80 else 80
+        right_margin = max_label_len * 5 if max_label_len * 5 > 80 else 80
         # Update right margin as well.
         figure['layout'].update({'margin': {'r': right_margin}})
 
@@ -157,13 +157,13 @@ class DendrogramModel(BaseModel):
                  for file_id in self._doc_term_matrix.index.values])
 
         # Extend the left margin to fit all labels.
-        figure['layout'].update({'margin': {'l': max_label_len * 6.2}})
+        figure['layout'].update({'margin': {'l': max_label_len * 6.7}})
 
         # Find the max x value in the plot.
         max_x = max([max(data['x']) for data in figure['data']])
 
         # Calculate proper x coordinate the figure should extend to.
-        x_value = math.ceil(max_x * 10) / 10
+        x_value = math.ceil(max_x * 100) / 100
 
         # Get the dummy scatter plot.
         dummy_scatter = self.get_dummy_scatter(x_value=x_value)

--- a/lexos/models/dendro_model.py
+++ b/lexos/models/dendro_model.py
@@ -1,14 +1,13 @@
 """This is a model to produce dendrograms of the dtms."""
 
-from typing import NamedTuple, Optional
-
+import math
 import pandas as pd
 import plotly.figure_factory as ff
-from plotly.graph_objs.graph_objs import Figure, Scatter
-from plotly.offline import plot
-from scipy.cluster.hierarchy import linkage
+from typing import NamedTuple, Optional
 from scipy.spatial.distance import pdist
-
+from scipy.cluster.hierarchy import linkage
+from plotly.offline import plot
+from plotly.graph_objs.graph_objs import Figure, Scatter
 from lexos.models.base_model import BaseModel
 from lexos.models.matrix_model import MatrixModel, IdTempLabelMap
 from lexos.receivers.dendro_receiver import DendroOption, DendroReceiver
@@ -95,7 +94,27 @@ class DendrogramModel(BaseModel):
         else:
             raise ValueError("Invalid orientation.")
 
+    @staticmethod
+    def get_dummy_scatter(x_value: int) -> Scatter:
+        """
+
+        :param x_value:
+        :return:
+        """
+        return Scatter(
+            x=[x_value],
+            y=[0],
+            mode="markers",
+            opacity=0,
+            hoverinfo="skip"
+        )
+
     def extend_top_figure(self, figure: Figure) -> Figure:
+        """
+
+        :param figure:
+        :return:
+        """
         # Get the length of longest label.
         max_label_len = \
             max([len(self._id_temp_label_map[file_id])
@@ -106,6 +125,11 @@ class DendrogramModel(BaseModel):
         return figure
 
     def extend_left_figure(self, figure: Figure) -> Figure:
+        """
+
+        :param figure:
+        :return:
+        """
         # Get the length of longest label.
         max_label_len = \
             max([len(self._id_temp_label_map[file_id])
@@ -113,25 +137,21 @@ class DendrogramModel(BaseModel):
 
         # Extend the left margin to fit all labels.
         figure['layout'].update({'margin': {'l': max_label_len * 7}})
+
+        # Find the max x value in the plot.
+        max_x = max([max(data['x']) for data in figure['data']])
+
+        # Find the max_x round up to the nearest tenth digit.
+
         return figure
 
     def extend_fig_boundary(self, figure: Figure) -> Figure:
 
         if self._dendro_option.orientation == "top":
-            x_value = [max([max(data['x']) for data in figure['data']]) + 3]
+
             figure["layout"]["xaxis"].update({"rangemode": "normal"})
         else:
             x_value = [max([max(data['x']) for data in figure['data']]) + 3]
-
-        dummy_scatter = Scatter(
-            x=x_value,
-            y=[0],
-            opacity=0,
-            mode="markers",
-            hoverinfo="skip"
-        )
-
-        figure['data'] += [dummy_scatter]
 
         return figure
 
@@ -153,9 +173,9 @@ class DendrogramModel(BaseModel):
         )
 
         # Adjust figure style based on the selected orientation.
-        figure = self.extend_fig_margin(figure=figure)
-        figure = self.extend_fig_boundary(figure=figure)
+        figure = self.extend_figure(figure=figure)
 
+        # Return the figure as div.
         return plot(
             figure_or_data=figure,
             show_link=False,

--- a/lexos/templates/dendrogram.html
+++ b/lexos/templates/dendrogram.html
@@ -12,7 +12,14 @@
 
 {% block options %}
     <fieldset>
-        <legend>Dendrogram Options <a class="btn bttn bttn-video" href="https://www.youtube.com/watch?v=Lir0ck691yM&list=PLEoAaCvaZOMMZD7x3SaQztPJxtpijv_gD&index=7" target="_blank" data-toggle="tooltip" data-placement="right" data-trigger="hover" title="Show video" style="margin: -10px 5px;"><i class="fa fa-video-camera fa-lg "></i></a></legend>
+        <legend>Dendrogram Options
+            <a class="btn bttn bttn-video" title="Show video"
+               href="https://www.youtube.com/watch?v=Lir0ck691yM&list=PLEoAaCvaZOMMZD7x3SaQztPJxtpijv_gD&index=7"
+               data-toggle="tooltip" data-trigger="hover"
+               data-placement="right" style="margin: -10px 5px;">
+                <i class="fa fa-video-camera fa-lg "></i>
+            </a>
+        </legend>
         <div class="dendrogram-options cf" id="dendrocreateoptions">
             <label for="metric">Distance Metric:
                 <select name="metric" id="metric">
@@ -71,7 +78,6 @@
                     <option value="complete" {{ 'selected' if session['hierarchyoption']['linkage'] == 'complete' }}>
                         Complete
                     </option>
-                    <!-- <option value="ward" {{ 'selected' if session['hierarchyoption']['linkage'] == 'ward' }}>Ward</option> -->
                     <option value="weighted" {{ 'selected' if session['hierarchyoption']['linkage'] == 'weighted' }}>
                         Weighted
                     </option>
@@ -84,18 +90,16 @@
             </label>
             <label for="orientation">Dendrogram Leaves Orientation:
                 <select name="orientation" id="orientation">
-                    <option value="top" {{ 'selected' if session['hierarchyoption']['orientation'] == 'top' }}>
-                        Top
+                    <option value="bottom" {{ 'selected' if session['hierarchyoption']['orientation'] == 'bottom' }}>
+                        Bottom
                     </option>
                     <option value="left" {{ 'selected' if session['hierarchyoption']['orientation'] == 'left' }}>
                         Left
                     </option>
-                    <option value="right" {{ 'selected' if session['hierarchyoption']['orientation'] == 'right' }}>
-                        Right
-                    </option>
-                    <option value="bottom" {{ 'selected' if session['hierarchyoption']['orientation'] == 'bottom' }}>
-                        Bottom
-                    </option>
+                    {# We comment these two options out since we don't think our users need them. #}
+                    {# But if we decide to add them back in the future, simply uncomment them. #}
+                    {# <option value="top" {{ 'selected' if session['hierarchyoption']['orientation'] == 'top' }}>Top</option> #}
+                    {# <option value="right" {{ 'selected' if session['hierarchyoption']['orientation'] == 'right' }}>Right</option> #}
                 </select>
             </label>
         </div>
@@ -106,15 +110,11 @@
 {% block results %}
     <div class="row submit-button-row">
         <div class="col-md-12">
-            <input class="bttn bttn-action" id="getdendro" name="getdendro"
+            <input class="btn btn-success" id="getdendro" name="getdendro"
                    type="button" value="Get Dendrogram" style=""/>
         </div>
     </div>
-
-    <div id="dendrogram-result" class="row">
-
-    </div>
-
+    <div id="dendrogram-result" class="row"></div>
 {% endblock %}
 
 {% block submit %}

--- a/test/unit_test/test_dendrogram_model.py
+++ b/test/unit_test/test_dendrogram_model.py
@@ -5,7 +5,7 @@ from lexos.models.dendro_model import DendroOption, DendrogramModel, \
     DendroTestOptions
 
 
-class TestsBasic:
+class TestLeftOrientation:
     test_options = DendroTestOptions(
         doc_term_matrix=pd.DataFrame(
             [
@@ -24,7 +24,7 @@ class TestsBasic:
         ),
 
         id_temp_label_map={
-            2: "this is a test",
+            2: "This is a test",
             4: "Cheng is handsome",
             10: "I look so good!"
         }
@@ -33,11 +33,11 @@ class TestsBasic:
     model = DendrogramModel(test_options=test_options)
 
     # noinspection PyProtectedMember
-    def test_get_dendro_graph(self):
-        basic_fig = self.model._get_dendrogram_fig()
+    def test_graph(self):
+        basic_fig = self.model._get_processed_dendrogram_figure()
         np.testing.assert_equal(
             basic_fig['layout']['yaxis']['ticktext'],
-            ['I look so good!', 'this is a test', 'Cheng is handsome']
+            ['I look so good!', 'This is a test', 'Cheng is handsome']
         )
         np.testing.assert_allclose(
             basic_fig['data'][0]['x'], [0., 5., 5., 0.]
@@ -50,4 +50,54 @@ class TestsBasic:
         )
         np.testing.assert_allclose(
             basic_fig['data'][1]['y'], [-5., -5., -20., -20.]
+        )
+
+
+class TestBottomOrientation:
+    test_options = DendroTestOptions(
+        doc_term_matrix=pd.DataFrame(
+            [
+                [0.0, 0.0, 9.0, 9.0, 0.0, 0.0, 5.0, 4.0],
+                [0.0, 0.0, 9.0, 9.0, 0.0, 0.0, 0.0, 4.0],
+                [5.0, 10.0, 0.0, 0.0, 10.0, 5.0, 0.0, 0.0]
+            ],
+            index=[2, 4, 10],
+            columns=['1', '2', '3', '4', '5', '6', '7', '8']
+        ),
+
+        front_end_option=DendroOption(
+            orientation='bottom',
+            linkage_method='average',
+            dist_metric='euclidean'
+        ),
+
+        id_temp_label_map={
+            2: "This is also a test",
+            4: "Weiqi is handsome as well",
+            10: "I look so good too!"
+        }
+    )
+
+    model = DendrogramModel(test_options=test_options)
+
+    # noinspection PyProtectedMember
+    def test_graph(self):
+        basic_fig = self.model._get_processed_dendrogram_figure()
+        np.testing.assert_equal(
+            basic_fig['layout']['xaxis']['ticktext'],
+            ['I look so good too!',
+             'This is also a test',
+             'Weiqi is handsome as well']
+        )
+        np.testing.assert_allclose(
+            basic_fig['data'][0]['x'], [15., 15., 25., 25.]
+        )
+        np.testing.assert_allclose(
+            basic_fig['data'][0]['y'], [0., 5., 5., 0.]
+        )
+        np.testing.assert_allclose(
+            basic_fig['data'][1]['x'], [5., 5., 20., 20.]
+        )
+        np.testing.assert_allclose(
+            basic_fig['data'][1]['y'], [0., 20.98597876, 20.98597876, 5.]
         )


### PR DESCRIPTION
### Fix dendrogram plotly graph
- Removed right and top orientation. 
- Added a padding so that most right leaf will not touch the border of the plot. (Note: The padding now will not go away when you zoom in and zoom out.)
- Dynamically extend plot margins so that long label will not get cut off.

### Below are two usage cases.
- Left orientation
![screenshot from 2018-07-28 16-29-00](https://user-images.githubusercontent.com/25487969/43360525-a50a0f22-9284-11e8-9cc4-21cf83700f59.png)
- Bottom orientation
![screenshot from 2018-07-28 16-29-59](https://user-images.githubusercontent.com/25487969/43360526-a820abb2-9284-11e8-9fec-9f8a8bf10b97.png)


