### PR TITLE
Mark content analysis as beta version

### DIFF
--- a/lexos/templates/contentanalysis.html
+++ b/lexos/templates/contentanalysis.html
@@ -112,9 +112,13 @@
         </div>
     </div>
     <div class="col-md-2">
-            <div class="col-md-1">
-                <input class="bttn bttn-action" id="analyze_button" value="Analyze" type="button" onclick="analyze()">
-            </div>
+        <input class="bttn bttn-action" id="analyze_button" value="Analyze" type="button" onclick="analyze()">
+        <i class="fa fa-question-circle lexos-tooltip-trigger"
+           data-toggle="tooltip" data-html="true"
+           data-placement="right" data-container="body"
+           title="This is a beta version of this tool. Thank you for being our first testers!"
+           style="padding-left:4px; font-size:18px; color:orangered">
+        </i>
     </div>
 </div>
 


### PR DESCRIPTION
Add a tooltip to hint users that content analysis is still a beta version.