### PR TITLE
Add an error page when scikit-bio is missing

### DIFF
--- a/lexos/templates/bct_analysis_import_error.html
+++ b/lexos/templates/bct_analysis_import_error.html
@@ -18,17 +18,18 @@
                 detect this library on your machine.
             </li>
             <li class="list-group-item-text">
-                If you with to use Lexos without Bootstrap Consensus Trees,
+                If you with to use Lexos without Bootstrap Consensus Tree,
                 you may ignore this message. The other Lexos tools will run
                 fine.
             </li>
             <li class="list-group-item-text">
-                if you with to use Bootstrap Consensus Trees tool without
+                If you with to use Bootstrap Consensus Tree tool without
                 installing <code>scikit-bio</code> on your machine, you can
-                visit our <a href="http://lexos.wheatoncollege.edu">server</a>.
+                visit our
+                <a href="http://lexos.wheatoncollege.edu">public server</a>.
             </li>
             <li class="list-group">
-                If you want to run Bootstrap Consensus Trees on your own
+                If you want to run Bootstrap Consensus Tree on your own
                 computer, follow the instructions below.
                 <ul class="list-group" style="list-style-type:disc">
                     <li class="list-group-item">

--- a/lexos/templates/bct_analysis_import_error.html
+++ b/lexos/templates/bct_analysis_import_error.html
@@ -10,28 +10,29 @@
      written, this page should be removed. -->
 {% block content %}
     <legend>Missing scikit-bio library!</legend>
-
     <div class="row col-lg-11 col-md-11" style="padding-left: 30px">
         <ul class="list-group" style="list-style-type:disc">
             <li class="list-group-item-danger">
-                We detected that scikit-bio library, which is required by this
-                tool, is missing.
+                The Bootstrap Consensus Tree tool requires the
+                <code>scikit-bio</code> Python library. Lexos was unable to
+                detect this library on your machine.
             </li>
             <li class="list-group-item-text">
-                If you don't want to use this tool, please ignore this message.
-                All the other tools in Lexos run fine without this library.
+                If you with to use Lexos without Bootstrap Consensus Trees,
+                you may ignore this message. The other Lexos tools will run
+                fine.
             </li>
             <li class="list-group-item-text">
-                If you intend to use this tool, but don't want to go through
-                the trouble installing the library, you can visit our
-                <a href="http://lexos.wheatoncollege.edu">server</a>.
+                if you with to use Bootstrap Consensus Trees tool without
+                installing <code>scikit-bio</code> on your machine, you can
+                visit our <a href="http://lexos.wheatoncollege.edu">server</a>.
             </li>
             <li class="list-group">
-                If you want to have this tool running on your localhost, you
-                can install scikit-learn.
+                If you want to run Bootstrap Consensus Trees on your own
+                computer, follow the instructions below.
                 <ul class="list-group" style="list-style-type:disc">
                     <li class="list-group-item">
-                        Mac/Linux users: Run <code>pip install scikit-bio</code>
+                        Mac/Linux users: Open a terminal and run <code>pip install scikit-bio</code>
                     </li>
                     <li class="list-group-item">
                         Windows users: Please follow the instructions on our

--- a/lexos/templates/bct_analysis_import_error.html
+++ b/lexos/templates/bct_analysis_import_error.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+{% set active_page = 'bct_analysis' %}
+
+{% block head %}{% endblock %}
+{% block title %}Bootstrap Consensus Tree{% endblock %}
+
+<!-- We have this page set up because scikit-bio library is hard to install on windows.
+     Thus if users choose to not to install scikit-bio, we display this page. -->
+{% block content %}
+    <legend>Missing scikit-bio library!</legend>
+
+    <div class="row col-lg-11 col-md-11" style="padding-left: 30px">
+        <ul class="list-group" style="list-style-type:disc">
+            <li class="list-group-item-danger">
+                We detected that scikit-bio library, which is required by this
+                tool, is missing.
+            </li>
+            <li class="list-group-item-text">
+                If you don't want to use this tool, please ignore this message.
+                All the other tools in Lexos run fine without this library.
+            </li>
+            <li class="list-group-item-text">
+                If you intend to use this tool, but don't want to go through
+                the trouble installing the library, you can visit our
+                <a href="http://lexos.wheatoncollege.edu">server</a>.
+            </li>
+            <li class="list-group">
+                If you want to have this tool running on your localhost, you
+                can install scikit-learn.
+                <ul class="list-group" style="list-style-type:disc">
+                    <li class="list-group-item">
+                        Mac/Linux users: Run <code>pip install scikit-bio</code>
+                    </li>
+                    <li class="list-group-item">
+                        Windows users: Please follow the instructions on our
+                        <a href="https://github.com/WheatonCS/Lexos/wiki/How-to-Install-scikit-bio-on-Windows">Wiki</a>.
+                    </li>
+                </ul>
+            </li>
+        </ul>
+    </div>
+{% endblock %}

--- a/lexos/templates/bct_analysis_import_error.html
+++ b/lexos/templates/bct_analysis_import_error.html
@@ -5,7 +5,9 @@
 {% block title %}Bootstrap Consensus Tree{% endblock %}
 
 <!-- We have this page set up because scikit-bio library is hard to install on windows.
-     Thus if users choose to not to install scikit-bio, we display this page. -->
+     Thus if users choose to not to install scikit-bio, we display this page.
+     And once scikit-bio better supports windows or an alternative method is
+     written, this page should be removed. -->
 {% block content %}
     <legend>Missing scikit-bio library!</legend>
 

--- a/lexos/views/bct_view.py
+++ b/lexos/views/bct_view.py
@@ -31,7 +31,7 @@ def bct_analysis():
         session['bctoption'] = constants.DEFAULT_BCT_OPTIONS
 
     try:
-        import skbio
+        from lexos.models.bct_model import BCTModel
         # Render the HTML template.
         return render_template(
             'bct_analysis.html',

--- a/lexos/views/bct_view.py
+++ b/lexos/views/bct_view.py
@@ -32,6 +32,8 @@ def bct_analysis():
 
     try:
         from lexos.models.bct_model import BCTModel
+        # Use a black hole variable to hold the model to get rid of warning.
+        _ = BCTModel()
         # Render the HTML template.
         return render_template(
             'bct_analysis.html',

--- a/lexos/views/bct_view.py
+++ b/lexos/views/bct_view.py
@@ -1,7 +1,6 @@
 from flask import session, render_template, Blueprint
 from lexos.helpers import constants
 from lexos.managers import session_manager
-from lexos.models.bct_model import BCTModel
 from lexos.views.base_view import detect_active_docs
 from lexos.models.filemanager_model import FileManagerModel
 
@@ -31,13 +30,20 @@ def bct_analysis():
     if 'bctoption' not in session:
         session['bctoption'] = constants.DEFAULT_BCT_OPTIONS
 
-    # Render the HTML template.
-    return render_template(
-        'bct_analysis.html',
-        itm="bct-analysis",
-        labels=id_label_map,
-        numActiveDocs=num_active_docs
-    )
+    try:
+        import skbio
+        # Render the HTML template.
+        return render_template(
+            'bct_analysis.html',
+            itm="bct-analysis",
+            labels=id_label_map,
+            numActiveDocs=num_active_docs
+        )
+    except ImportError:
+        return render_template(
+            'bct_analysis_import_error.html',
+            itm="bct-analysis"
+        )
 
 
 @bct_analysis_blueprint.route("/bct_analysis_result", methods=['POST'])
@@ -46,6 +52,8 @@ def get_bct_result():
 
     :return: Send file from directory to the ajax call.
     """
+    # Import the model module.
+    from lexos.models.bct_model import BCTModel
     # Cache all the options.
     session_manager.cache_bct_option()
     session_manager.cache_analysis_option()


### PR DESCRIPTION
@scottkleinman suggested this approach and I think this is the best way to remain only one release. 
So when `bct_view` detects that the scikit-bio library is missing, it renders a different page with some options user can choose from. This way, even if scikit-bio is missing, users can still use the rest of Lexos.