### PR TITLE
Remove the 32 bit test

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,10 +2,6 @@
 environment:
   # Run for both architecture for python 3.7.x
   matrix:
-    - PYTHON: "C:\\Python37"
-      PYTHON_VERSION: "3.7"
-      PYTHON_ARCH: "32"
-
     - PYTHON: "C:\\Python37-x64"
       PYTHON_VERSION: "3.7"
       PYTHON_ARCH: "64"


### PR DESCRIPTION
Since Appveyor does not run tasks in parallel, remove the unnecessary 32 bit Windows test.