### PR TITLE
second option for leading zeros cutter fix

### DIFF
--- a/lexos/managers/file_manager.py
+++ b/lexos/managers/file_manager.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import zipfile
 from cmath import sqrt, log, exp
+from math import floor, log10
 from os import makedirs
 from os.path import join as pathjoin
 from typing import List, Tuple, Dict
@@ -354,12 +355,14 @@ class FileManager:
             l_file.active = False
 
             children_file_contents = l_file.cut_contents()
+            num_cut_files = len(children_file_contents)
             l_file.save_cut_options(parent_id=None)
 
             if saving_changes:
                 for i, file_string in enumerate(children_file_contents):
                     original_filename = l_file.name
-                    doc_label = l_file.label + '_' + str(i + 1)
+                    zeros = floor(log10(num_cut_files)) - floor(log10(i+1))
+                    doc_label = l_file.label + '_' + ('0' * zeros) + str(i + 1)
                     file_id = self.add_file(
                         original_filename, doc_label + '.txt', file_string)
 

--- a/lexos/managers/file_manager.py
+++ b/lexos/managers/file_manager.py
@@ -416,8 +416,11 @@ class FileManager:
             as_attachment=True)
 
     def zip_active_files_with_leading_zeros(self, zip_file_name: str):
-        """Sends a zip file of files containing contents of the active files.
+        """Sends a zip file of active files with leading 0s added to numbering.
 
+        This function is a modification of the one above intended to go with
+        the "Download Cut Files" button--the downloaded files will be more
+        easily sortable as a result.
         :param zip_file_name: Name to assign to the zipped file.
         :return: zipped archive to send to the user, created with Flask's
                      send_file.

--- a/lexos/templates/cut.html
+++ b/lexos/templates/cut.html
@@ -302,8 +302,7 @@
        role="button">Preview Cuts</a>
     <a id="apply-btn" class="btn btn-success cutTrigger" onclick="process('apply')"
        role="button">Apply Cuts</a>
-    <a id="downloadCutting" class="btn btn-info" role="button">Download Cut
-        Files</a>
+    <input class="btn btn-info" type="submit" value="Download Cut Files">
     <input type="hidden" id="formAction" name="formAction" value="preview">
     <input type="hidden" id="hasErrors" name="hasErrors" value="false">
     <input type="hidden" id="needsWarning" name="needsWarning" value="false">

--- a/lexos/views/cut_view.py
+++ b/lexos/views/cut_view.py
@@ -14,7 +14,7 @@ from lexos.views.base_view import detect_active_docs
 cutter_blueprint = Blueprint('cutter', __name__)
 
 
-@cutter_blueprint.route("/cut", methods=["GET", "POST"])
+@cutter_blueprint.route("/cut", methods=["GET"])
 def cut():
     """ Handles the functionality of the cut page.
 
@@ -63,7 +63,7 @@ def cut():
             numActiveDocs=num_active_docs)
 
 
-@cutter_blueprint.route("/downloadCutting", methods=["GET", "POST"])
+@cutter_blueprint.route("/cut", methods=["POST"])
 def download_cutting():
     """downloads cut files.
 
@@ -72,7 +72,7 @@ def download_cutting():
     # The 'Download Segmented Files' button is clicked on cut.html
     # sends zipped files to downloads folder
     file_manager = utility.load_file_manager()
-    return file_manager.zip_active_files('cut_files.zip')
+    return file_manager.zip_active_files_with_leading_zeros('cut_files.zip')
 
 
 @cutter_blueprint.route("/doCutting", methods=["GET", "POST"])


### PR DESCRIPTION
#838
this one uses the "Download Cut Files" button specifically to access a new function that changes the filenames before zipping them up for download. internally, the numbering remains the same as it was.