### PR TITLE
Changed version number displayed in base.html

### DIFF
--- a/lexos/templates/base.html
+++ b/lexos/templates/base.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8"/>
     <title>Lexos</title>
 
-    {%- set version = "3.2.0" %}
+    {%- set version = "3.2.2" %}
 
     <meta http-equiv="cache-control" content="max-age=0"/>
     <meta http-equiv="expires" content="0"/>


### PR DESCRIPTION
As Lexos itself changes and we add more features and bugfixes, the version number needs to be updated.