### PR TITLE
front end rewrite/restore old rolling window colors

### DIFF
--- a/lexos/models/rolling_windows_model.py
+++ b/lexos/models/rolling_windows_model.py
@@ -407,12 +407,9 @@ class RollingWindowsModel(BaseModel):
         :return: A string that contains the desired RGB color.
         """
 
-        return "#505050" if self._options.plot_options.black_white \
-               else "#47BCFF"
-
-        # return cl.scales['8']['qual']['Set1'][index % 8] \
-        #     if not self._options.plot_options.black_white \
-        #     else cl.scales['7']['seq']['Greys'][6 - index % 6]
+        return cl.scales['8']['qual']['Set1'][index % 8] \
+            if not self._options.plot_options.black_white \
+            else cl.scales['7']['seq']['Greys'][6 - index % 6]
 
     def _get_mile_stone_color(self, index: int) -> str:
         """Get color for mile stone.


### PR DESCRIPTION
graphs are easier to read when individual search terms get their own colors.
current behavior:
![old](https://user-images.githubusercontent.com/50586789/59041657-0cc7ff80-8847-11e9-80ea-cb92054a31bc.png)
using old front-end coloring behavior:
![new](https://user-images.githubusercontent.com/50586789/59041664-10f41d00-8847-11e9-8e29-39f72c98f061.png)
