### PR TITLE
front-end-rewrite/rolling window ratio search

### DIFF
--- a/lexos/static/css/helpers/base.css
+++ b/lexos/static/css/helpers/base.css
@@ -115,6 +115,10 @@ form {
     opacity: 0;
 }
 
+.hidden {
+    display: none;
+}
+
 .center-justified {
     justify-self: center;
 }

--- a/lexos/static/js/helpers/utility.js
+++ b/lexos/static/js/helpers/utility.js
@@ -199,7 +199,7 @@ function fade_in(query, duration = ".2s", sequential_delay = 0){
         element.css({"transition": "none", "opacity": "0"});
 
         // Show the element
-        element.removeClass("invisible");
+        element.removeClass("hidden");
 
         // Fade the element after a delay
         setTimeout(function(){

--- a/lexos/static/js/helpers/utility.js
+++ b/lexos/static/js/helpers/utility.js
@@ -199,7 +199,7 @@ function fade_in(query, duration = ".2s", sequential_delay = 0){
         element.css({"transition": "none", "opacity": "0"});
 
         // Show the element
-        element.removeClass("hidden");
+        element.removeClass("invisible");
 
         // Fade the element after a delay
         setTimeout(function(){

--- a/lexos/static/js/rolling-window.js
+++ b/lexos/static/js/rolling-window.js
@@ -21,10 +21,10 @@ $(function(){
     let rolling_ratio_element = $("#rolling-ratio-button");
     let ratio_search_terms = $("#ratio-search-terms-input");
     rolling_average_element.click(function(){
-        ratio_search_terms.addClass("invisible");
+        ratio_search_terms.addClass("hidden");
     });
     rolling_ratio_element.click(function(){
-        fade_in(ratio_search_terms);
+        ratio_search_terms.removeClass("hidden")
     });
 });
 

--- a/lexos/static/js/rolling-window.js
+++ b/lexos/static/js/rolling-window.js
@@ -13,6 +13,16 @@ $(function(){
 
         // If the request failed, display an error
         .fail(function(){ error("Failed to retrieve the active files."); });
+
+    let rolling_average_element = $("#rolling-average-button");
+    let rolling_ratio_element = $("#rolling-ratio-button");
+    let ratio_search_terms = $("#ratio-search-terms-input");
+    rolling_average_element.click(function(){
+        ratio_search_terms.addClass("invisible");
+    });
+    rolling_ratio_element.click(function(){
+        fade_in(ratio_search_terms);
+    });
 });
 
 

--- a/lexos/templates/rolling-window.html
+++ b/lexos/templates/rolling-window.html
@@ -24,8 +24,8 @@
         <div id="calculation-type-section" class="section">
             <h3 class="section-top title">Calculation Type</h3>
             <div class="section-body">
-                <label class="circle-label"><input name="counttype" value="average" type="radio" checked><span>Rolling Average</span></label><br>
-                <label class="circle-label"><input name="counttype" value="ratio" type="radio"><span>Rolling Ratio</span></label>
+                <label class="circle-label"><input id="rolling-average-button" name="counttype" value="average" type="radio" checked><span>Rolling Average</span></label><br>
+                <label class="circle-label"><input id="rolling-ratio-button" name="counttype" value="ratio" type="radio"><span>Rolling Ratio</span></label>
             </div>
         </div>
 
@@ -34,6 +34,7 @@
             <h3 class="section-top title">Search Terms</h3>
             <div class="section-body">
                 <input id="search-terms-input" name="rollingsearchword" type="text" spellcheck="false" autocomplete="off"><br>
+                <input class="invisible" id="ratio-search-terms-input" name="rollingsearchwordopt" type="text" spellcheck="false" autocomplete="off"><br>
                 <label class="circle-label"><input name="inputtype" value="word" type="radio" checked><span>Words</span></label><br>
                 <label class="circle-label"><input name="inputtype" value="string" type="radio"><span>Strings</span></label><br>
                 <label class="circle-label"><input name="inputtype" value="regex" type="radio"><span>Regex</span></label>

--- a/lexos/templates/rolling-window.html
+++ b/lexos/templates/rolling-window.html
@@ -40,7 +40,7 @@
             <div class="section-body">
                 <input id="search-terms-input" name="rollingsearchword" type="text" spellcheck="false" autocomplete="off">
                 <h3 id="search-terms-input-tooltip-button" class="button">?</h3><br>
-                <input class="invisible" id="ratio-search-terms-input" name="rollingsearchwordopt" type="text" spellcheck="false" autocomplete="off"><br>
+                <input class="hidden" id="ratio-search-terms-input" name="rollingsearchwordopt" type="text" spellcheck="false" autocomplete="off"><br>
                 <label class="circle-label"><input name="inputtype" value="word" type="radio" checked><span>Words</span></label><br>
 
                 <label class="circle-label"><input name="inputtype" value="string" type="radio"><span>Strings</span></label>


### PR DESCRIPTION
adds a box for ratio search terms that appears when the option is selected
not sure if this is the best way to do this? it makes the upper section take up more of the page. the style may also not be consistent with the rest of the html; could use some feedback/edits @Myles-Trevino 