### PR TITLE
Bugfix/cutter whitespace

### DIFF
--- a/lexos/processors/prepare/cutter.py
+++ b/lexos/processors/prepare/cutter.py
@@ -95,8 +95,8 @@ def cut_by_characters(text: str, seg_size: int, overlap: int,
     assert overlap >= 0 and last_prop >= 0, NEG_OVERLAP_LAST_PROP_MESSAGE
     assert seg_size > overlap, LARGER_SEG_SIZE_MESSAGE
 
-    # split all the chars while keeping all the whitespace
-    seg_list = re.findall(r"\S", text)
+    # chop up the string by characters (keeping whitespace)
+    seg_list = [char for char in text]
 
     # add sub-lists(segment) to final list
     final_seg_list = cut_list_with_overlap(input_list=seg_list,


### PR DESCRIPTION
## Before:
Choosing to cut by character in Cutter removed all whitespace, and simply changing the regex to accepting all characters nukes newlines for some reason
## After: 
I removed the Regex in `cut_by_characters` in `cutter.py` in favor of very simply just separating the input string into a list of characters and feeding that to the rest of the function