### PR TITLE
Front end rewrite/scrubber fixes

### DIFF
--- a/lexos/processors/prepare/scrubber.py
+++ b/lexos/processors/prepare/scrubber.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
-import re
+import regex as re
 import sys
 import unicodedata
 from typing import List, Dict, Match
@@ -476,8 +476,9 @@ def get_remove_digits(text: str) -> str:
     # unicode digits, this pattern will match:
     # 1) ***
     # 2) ***.***
-    pattern = re.compile(r"([+-]?\d+)|((?<=\d)[\u0027|\u002C|\u002E|\u00B7"
-                         r"|\u02D9|\u066B|\u066C|\u2396]\d+)", re.UNICODE)
+    pattern = re.compile(r"([+-]?\p{Nd}+|\p{No}+|\p{Nl}+)|((?<=\p{Nd}|\p{No}|"
+                         r"\p{Nl})[\u0027|\u002C|\u002E|\u00B7|\u02D9|\u066B|"
+                         r"\u066C|\u2396]\p{Nd}+|\p{No}+|\p{Nl}+)", re.UNICODE)
     remove_digits = str(re.sub(pattern, r"", text))
 
     return remove_digits

--- a/lexos/views/scrub.py
+++ b/lexos/views/scrub.py
@@ -54,9 +54,9 @@ def execute() -> str:
     # Scrub
     previews = file_manager.scrub_files(saving_changes=saving_changes)
 
-    # HTML escape the previews
-    previews = [[preview[1], general_functions.html_escape(preview[3])]
-                for preview in previews]
+    # (DO NOT) HTML escape the previews (THIS LINE USED TO DO THAT, BUT NOW
+    # IT JUST PUTS THE DATA IN THE CORRECT FORMAT OR SOMETHING)
+    previews = [[preview[1], preview[3]] for preview in previews]
 
     # Save the changes if requested
     if saving_changes:

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ colorlover
 matplotlib
 scikit-learn
 beautifulsoup4
+regex


### PR DESCRIPTION
fixed two scrubber issues:
- text sent to preview is no longer html-escaped because it doesn't need to be
- new digits regex now also catches digits from other Unicode catgeories (No, Nl, Nd); this required adding extended regex package