### PR TITLE
scrub whitespace fix

### DIFF
--- a/lexos/processors/prepare/scrubber.py
+++ b/lexos/processors/prepare/scrubber.py
@@ -953,7 +953,7 @@ def scrub(text: str, gutenberg: bool, lower: bool, punct: bool, apos: bool,
 
     # -- 6. whitespace ------------------------------------------------------
 
-    if white_space:
+    if spaces or tabs or new_lines:
         remove_whitespace_map = get_remove_whitespace_map(
             spaces, tabs, new_lines)
     else:


### PR DESCRIPTION
scrub function previously checked for a general "remove whitespace" checkbox that has been removed in new front end
now it will just check if any of the three sub-options are checked