### PR TITLE
Fix/walkthru color change back

### DIFF
--- a/lexos/static/css/helpers/base.css
+++ b/lexos/static/css/helpers/base.css
@@ -564,14 +564,14 @@ label input[type="checkbox"]:checked + span:after {
     font-size: 1.3rem;
     border-radius: 50%;
     transition: color .2s, background-color .2s;
-    color: var(--secondary-highlight-color);
-    background-color: var(--secondary-highlight-color-light);
+    color: var(--button-border-color);
+    background-color: var(--foreground-color);
 }
 
 .tooltip-button:hover,
 .tooltip-button-active {
     color: var(--foreground-color);
-    background-color: var(--secondary-highlight-color);
+    background-color: var(--button-border-color);
 }
 
 

--- a/lexos/static/css/helpers/base.css
+++ b/lexos/static/css/helpers/base.css
@@ -207,13 +207,14 @@ form {
 #navbar-walkthrough-button {
     font-family: Libre Baskerville;
     margin-bottom: 1.6rem;
-    color: var(--foreground-color);
-    background-color: var(--secondary-highlight-color);
+    border-radius: 50%;
+    border: .20rem solid var(--button-border-color);
+    background-color: var(--foreground-color);
 }
 
 #navbar-walkthrough-button:hover {
-    color: var(--secondary-highlight-color);
-    background-color: var(--secondary-highlight-color-light);
+    color: var(--foreground-color);
+    background-color: var(--button-border-color);
 }
 
 #navbar-right > a,


### PR DESCRIPTION
changed the color of the walkthru button from orange to a more page-centric color (and so that it's function doesn't get mistaken for that of a tooltip button)