### PR TITLE
Fixed countVectorizer for scikit-learn version 1.3.2

### DIFF
--- a/lexos/helpers/definitions.py
+++ b/lexos/helpers/definitions.py
@@ -23,7 +23,7 @@ _SINGLE_RIGHT_WORD_BOUNDARY_REGEX_STR = r'\s|$'
 
 # ============== compiled version ==================
 # the compiled version of word regex
-WORD_REGEX = re.compile(_WORD_REGEX_STR, re.UNICODE)
+WORD_REGEX = _WORD_REGEX_STR
 
 
 def count_phrase_in_text(phrase: str, text: str) -> int:

--- a/lexos/managers/utility.py
+++ b/lexos/managers/utility.py
@@ -311,7 +311,7 @@ def simple_vectorizer(content: str, token_type: str, token_size: int):
             token_size),
         token_pattern=r"(?u)\b\w+\b")
     dtm = vectorizer.fit_transform(content)  # a sparse matrix
-    vocab = vectorizer.get_feature_names()  # a list
+    vocab = vectorizer.get_feature_names_out()  # a numpy.ndarray
     dtm = dtm.toarray()  # convert to a regular array
     vocab = np.array(vocab)
     return dtm, vocab

--- a/lexos/models/matrix_model.py
+++ b/lexos/models/matrix_model.py
@@ -123,7 +123,7 @@ class MatrixModel(BaseModel):
         # need to get at the entire matrix and not sparse matrix
         raw_count_matrix = doc_term_sparse_matrix.toarray()
         # snag all features (e.g., word-grams or char-grams) that were counted
-        words = count_vector.get_feature_names()
+        words = count_vector.get_feature_names_out()
         # pack the data into a data frame
         return pd.DataFrame(data=raw_count_matrix,
                             index=file_ids,

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,6 @@ numpy<=1.24.4
 pandas<2.0.0
 plotly<=5.19.0
 requests<=2.31.0
-scikit-learn==1.4.1.post1
+scikit-learn==1.3.2
 scipy<=1.10.1
 werkzeug==2.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,6 @@ numpy<=1.24.4
 pandas<2.0.0
 plotly<=5.19.0
 requests<=2.31.0
-scikit-learn<1.0.0
+scikit-learn==1.4.1.post1
 scipy<=1.10.1
 werkzeug==2.0.2


### PR DESCRIPTION
Updated scikit-learn to version 1.3.2 and updated associated code sections that used removed methods to use the newer versions.